### PR TITLE
기본 정렬 변경, 아이디 익명 출력으로 변환

### DIFF
--- a/theCommunityProject/articles/templates/article_detail.html
+++ b/theCommunityProject/articles/templates/article_detail.html
@@ -210,13 +210,13 @@
     {% endif %}
 
     <div style="margin-bottom: 1rem;">
-      {% if request.GET.sort == 'popular' %}
+      {% if request.GET.sort == 'popular' or not request.GET.sort %}
       <strong>인기순</strong>
       {% else %}
       <a href="?sort=popular">인기순</a>
       {% endif %}
 
-      {% if request.GET.sort == 'recent' or not request.GET.sort %}
+      {% if request.GET.sort == 'recent' %}
       <strong>최신순</strong>
       {% else %}
       <a href="?sort=recent">최신순</a>
@@ -226,8 +226,7 @@
     {% for comment in comments %}
     <div id="comment_{{ comment.id }}" style="border-top:1px solid #000; padding:10px 0;">
       <strong>{{ comment.user.username }}</strong>
-      <small>{% if comment.user.sex == 'M' %}(남성){% elif comment.user.sex == 'F' %}(여성){% else %}(기타){% endif
-        %}</small>:
+      <small>{% if comment.user.sex == 'M' %}(남성){% elif comment.user.sex == 'F' %}(여성){% else %}(기타){% endif %}</small>:
 
       {% if editing_comment_id == comment.id %}
       <!-- <form method="post" action="{% url 'articles:comment_update' article.id comment.id %}">
@@ -260,24 +259,23 @@
       </p>
 
       {% if opened_reply_comment_id == comment.id %}
-      <div id="reply-section-{{ comment.id }}" style="display:block;">
-        {% else %}
+        <div id="reply-section-{{ comment.id }}" style="display:block;">
+      {% else %}
         <div id="reply-section-{{ comment.id }}" style="display:none;">
-          {% endif %}
+      {% endif %}
 
-          {% for reply in comment.article_replies.all %}
+        {% for reply in comment.article_replies.all %}
           <div id="reply_{{ reply.id }}">
             <strong>{{ reply.user.username }}</strong>
-            <small>{% if reply.user.sex == 'M' %}(남성){% elif reply.user.sex == 'F' %}(여성){% else %}(기타){% endif
-              %}</small>:
+            <small>{% if reply.user.sex == 'M' %}(남성){% elif reply.user.sex == 'F' %}(여성){% else %}(기타){% endif %}</small>:
 
-            {% if editing_reply_id == reply.id %}
+          {% if editing_reply_id == reply.id %}
             <!-- <form method="post" action="{% url 'articles:reply_update' article.id comment.id reply.id %}">
               {% csrf_token %}
               <textarea name="content" style="width:100%; height:60px;">{{ reply.content }}</textarea><br>
               <button type="submit">수정 완료</button>
             </form> -->
-            {% else %}
+          {% else %}
             <p>{{ reply.content }}</p>
             {% if request.user == reply.user %}
             <!-- <form method="get" action="">
@@ -293,10 +291,10 @@
             {% else %}
             <button>신고하기</button>
             {% endif %}
-            {% endif %}
+          {% endif %}
 
-            <small>{{ reply.created_at|date:"Y.m.d" }}</small>
-            <a href="{% url 'articles:reply_like' article.id comment.id reply.id %}">❤️ {{ reply.liked.count }}</a>
+          <small>{{ reply.created_at|date:"Y.m.d" }}</small>
+          <a href="{% url 'articles:reply_like' article.id comment.id reply.id %}">❤️ {{ reply.liked.count }}</a>
           </div>
           {% empty %}
           <p>대댓글이 없습니다.</p>
@@ -309,9 +307,9 @@
           </form>
         </div>
       </div>
-      {% empty %}
-      <p>아직 의견이 없습니다.</p>
-      {% endfor %}
+    {% empty %}
+    <p>아직 의견이 없습니다.</p>
+    {% endfor %}
 
       <h3>댓글 작성</h3>
       <form method="post" action="{% url 'articles:comment_create' article.id %}">

--- a/theCommunityProject/articles/templates/article_detail.html
+++ b/theCommunityProject/articles/templates/article_detail.html
@@ -225,7 +225,7 @@
 
     {% for comment in comments %}
     <div id="comment_{{ comment.id }}" style="border-top:1px solid #000; padding:10px 0;">
-      <strong>{{ comment.user.username }}</strong>
+      <strong>{{ comment.anonymous_name }}</strong>
       <small>{% if comment.user.sex == 'M' %}(남성){% elif comment.user.sex == 'F' %}(여성){% else %}(기타){% endif %}</small>:
 
       {% if editing_comment_id == comment.id %}
@@ -266,7 +266,7 @@
 
         {% for reply in comment.article_replies.all %}
           <div id="reply_{{ reply.id }}">
-            <strong>{{ reply.user.username }}</strong>
+            <strong>{{ reply.anonymous_name }}</strong>
             <small>{% if reply.user.sex == 'M' %}(남성){% elif reply.user.sex == 'F' %}(여성){% else %}(기타){% endif %}</small>:
 
           {% if editing_reply_id == reply.id %}

--- a/theCommunityProject/articles/templates/article_home.html
+++ b/theCommunityProject/articles/templates/article_home.html
@@ -117,13 +117,13 @@
 
   <main>
     <div style="padding: 1rem 2rem;">
-      {% if request.GET.sort == 'popular' %}
+      {% if request.GET.sort == 'popular' or not request.GET.sort %}
       <strong>인기순</strong>
       {% else %}
       <a href="?sort=popular">인기순</a>
       {% endif %}
 
-      {% if request.GET.sort == 'recent' or not request.GET.sort %}
+      {% if request.GET.sort == 'recent' %}
       <strong>최신순</strong>
       {% else %}
       <a href="?sort=recent">최신순</a>

--- a/theCommunityProject/articles/views.py
+++ b/theCommunityProject/articles/views.py
@@ -63,15 +63,44 @@ def detail(request, article_id):
         except ArticleReply.DoesNotExist:
             editing_reply_id = None
 
+    # 댓글 목록 가져오기(답글까지 같이 가져옴)        
+    comments = article.article_comments.all().prefetch_related('article_replies', 'user')
+    
     sort = request.GET.get('sort', 'popular')
-    comments = article.article_comments.filter(created_at__isnull=False)
+    
     if sort == 'popular':
         comments = sorted(comments, key=lambda c: c.liked.count(), reverse=True)
     else:
         comments = comments.order_by('-created_at')
 
-    #관련된 커뮤니티 게시글
-    related_posts = Post.objects.filter(related_article=article).order_by('-created_at')
+    # 익명 이름 부여
+    all_entries = []
+    for comment in comments:
+        # 더미 코멘트 포함 안 함
+        if comment.created_at:
+            all_entries.append((comment.user.id, comment.created_at))
+        for reply in comment.article_replies.all():
+            # 더미 코멘트 포함 안 함
+            if reply.created_at:
+                all_entries.append((reply.user.id, reply.created_at))
+    
+    # 작성 시간 순 정렬
+    all_entries.sort(key=lambda x: x[1])
+    # 익명 번호 매핑
+    anon_map = {}
+    counter = 1
+    for user_id, _ in all_entries:
+        if user_id not in anon_map:
+            anon_map[user_id] = f"익명{counter}"
+            counter += 1
+    # 객체에 익명 번호 부여
+    for comment in comments:
+        comment.anonymous_name = anon_map.get(comment.user.id, "익명?")
+        for reply in comment.article_replies.all():
+            reply.anonymous_name = anon_map.get(reply.user.id, "익명?")
+
+    #관련된 커뮤니티 게시글(3개까지만 출력)
+    related_posts = Post.objects.filter(related_article=article).order_by('-created_at')[:3]
 
     for post in related_posts:
         post.filtered_comments = post.comments.filter(created_at__isnull=False)

--- a/theCommunityProject/articles/views.py
+++ b/theCommunityProject/articles/views.py
@@ -10,7 +10,7 @@ from community.models import Post
 # 홈: 아티클 목록
 @login_required(login_url='accounts:login')
 def home(request):
-    sort = request.GET.get('sort', 'recent')
+    sort = request.GET.get('sort', 'popular')
     articles = Article.objects.all()
 
     if sort == 'popular':
@@ -63,7 +63,7 @@ def detail(request, article_id):
         except ArticleReply.DoesNotExist:
             editing_reply_id = None
 
-    sort = request.GET.get('sort', 'recent')
+    sort = request.GET.get('sort', 'popular')
     comments = article.article_comments.filter(created_at__isnull=False)
     if sort == 'popular':
         comments = sorted(comments, key=lambda c: c.liked.count(), reverse=True)

--- a/theCommunityProject/proposals/templates/proposals_detail.html
+++ b/theCommunityProject/proposals/templates/proposals_detail.html
@@ -163,13 +163,13 @@
   <hr>
   <h3>제안 ({{ post.proposal_comments.count }})</h3>
   <!-- 정렬 -->
-  {% if request.GET.sort == 'popular' %}
+  {% if request.GET.sort == 'popular' or not request.GET.sort %}
   <strong>인기순</strong>
   {% else %}
   <a href="?sort=popular{% if request.GET.filter == 'petition' %}&filter=petition{% endif %}">인기순</a>
   {% endif %}
 
-  {% if request.GET.sort == 'recent' or not request.GET.sort %}
+  {% if request.GET.sort == 'recent' %}
   <strong>최신순</strong>
   {% else %}
   <a href="?sort=recent{% if request.GET.filter == 'petition' %}&filter=petition{% endif %}">최신순</a>
@@ -178,10 +178,11 @@
   <!-- 청원 24 필터 -->
   <form method="get" style="display:inline;">
     {% if request.GET.sort %}
-    <input type="hidden" name="sort" value="{{ request.GET.sort }}">
+      <input type="hidden" name="sort" value="{{ request.GET.sort }}">
     {% endif %}
     <label>
-      <input type="checkbox" name="filter" value="petition" {% if request.GET.filter=='petition' %}checked{% endif %}
+      <input type="checkbox" name="filter" value="petition" 
+        {% if request.GET.filter == 'petition' %}checked{% endif %}
         onchange="this.form.submit()">
       청원 24에 올라간 제안
     </label>
@@ -193,7 +194,7 @@
       {% if comment.link_url %}
       <span style="background-color: #a57bff;">국민청원등록</span>
       {% endif %}
-      {% if comment.liked.count >= 100 %}
+      {% if comment.is_best %}
       <span style="background-color: gray">Best</span>
       {% endif %}
     </div>
@@ -203,20 +204,20 @@
     <p><b>개선 방안:</b> {{ comment.solution }}</p>
     <p><b>기대 효과:</b> {{ comment.effect }}</p>
     {% if request.user == comment.user %}
-    <!-- <button
-      onclick="openEditCommentModal('{{ comment.title|escapejs }}', '{{ comment.problem|escapejs }}', '{{ comment.solution|escapejs }}', '{{ comment.effect|escapejs }}', '{% url 'proposals:detail_comment_update' post.id comment.id %}')">수정</button> -->
+      <!-- <button
+        onclick="openEditCommentModal('{{ comment.title|escapejs }}', '{{ comment.problem|escapejs }}', '{{ comment.solution|escapejs }}', '{{ comment.effect|escapejs }}', '{% url 'proposals:detail_comment_update' post.id comment.id %}')">수정</button> -->
 
-    <form method="post" action="{% url 'proposals:detail_comment_delete' post.id comment.id %}" style="display:inline;">
-      {% csrf_token %}
-      <button type="submit" onclick="return confirm('댓글을 삭제하시겠습니까?');">삭제</button>
-    </form>
+      <form method="post" action="{% url 'proposals:detail_comment_delete' post.id comment.id %}" style="display:inline;">
+        {% csrf_token %}
+        <button type="submit" onclick="return confirm('댓글을 삭제하시겠습니까?');">삭제</button>
+      </form>
 
-    {% if comment.link_url %}
-    <button
-      onclick="openLinkModal('{{ comment.link_url }}', '{% url 'proposals:detail_comment_link' post.id comment.id %}')">링크편집</button>
-    {% else %}
-    <button onclick="openLinkModal('', '{% url 'proposals:detail_comment_link' post.id comment.id %}')">링크추가</button>
-    {% endif %}
+      {% if comment.link_url %}
+      <button
+        onclick="openLinkModal('{{ comment.link_url }}', '{% url 'proposals:detail_comment_link' post.id comment.id %}')">링크편집</button>
+      {% else %}
+      <button onclick="openLinkModal('', '{% url 'proposals:detail_comment_link' post.id comment.id %}')">링크추가</button>
+      {% endif %}
 
     {% else %}
     <button>신고하기</button>
@@ -235,15 +236,14 @@
 
     {% if comment.id == opened_reply_comment_id %}
     <div id="reply-section-{{ comment.id }}" style="display:block;">
-      {% else %}
-      <div id="reply-section-{{ comment.id }}" style="display:none;">
-        {% endif %}
-        {% for reply in comment.proposal_replies.all %}
+    {% else %}
+    <div id="reply-section-{{ comment.id }}" style="display:none;">
+    {% endif %}
+      {% for reply in comment.proposal_replies.all %}
         <div id="reply_{{ reply.id }}">
           <strong>{{ reply.user.username }}{% if reply.user == comment.user %} (글쓴이){% endif %}</strong>
           <!-- 성별 출력 추가 -->
-          <small>{% if reply.user.sex == 'M' %}(남성){% elif reply.user.sex == 'F' %}(여성){% else %}(기타){% endif
-            %}</small>:
+          <small>{% if reply.user.sex == 'M' %}(남성){% elif reply.user.sex == 'F' %}(여성){% else %}(기타){% endif %}</small>:
           {% if editing_reply_id == reply.id %}
           <!-- <form method="post" action="{% url 'proposals:detail_reply_update' post.id comment.id reply.id %}">
             {% csrf_token %}
@@ -253,25 +253,25 @@
             <a href="{% url 'proposals:detail' post.id %}?open_reply={{ comment.id }}">취소</a>
           </form> -->
           {% else %}
-          <p>{{ reply.content }}</p>
-          <small>{{ reply.created_at|date:"Y.m.d" }}</small>
-          <a href="{% url 'proposals:detail_reply_like' post.id comment.id reply.id %}">❤️ {{ reply.liked.count }}</a>
-          {% if request.user == reply.user %}
-          <!-- <a
-            href="{% url 'proposals:detail' post.id %}?edit_reply={{ reply.id }}&open_reply={{ comment.id }}#reply_{{ reply.id }}">수정</a> -->
-          <form method="post" action="{% url 'proposals:detail_reply_delete' post.id comment.id reply.id %}"
-            style="display:inline;">
-            {% csrf_token %}
-            <button type="submit" onclick="return confirm('대댓글을 삭제하시겠습니까?');">삭제</button>
-          </form>
-          {% else %}
-          <button>신고하기</button>
-          {% endif %}
+            <p>{{ reply.content }}</p>
+            <small>{{ reply.created_at|date:"Y.m.d" }}</small>
+            <a href="{% url 'proposals:detail_reply_like' post.id comment.id reply.id %}">❤️ {{ reply.liked.count }}</a>
+            {% if request.user == reply.user %}
+            <!-- <a
+              href="{% url 'proposals:detail' post.id %}?edit_reply={{ reply.id }}&open_reply={{ comment.id }}#reply_{{ reply.id }}">수정</a> -->
+            <form method="post" action="{% url 'proposals:detail_reply_delete' post.id comment.id reply.id %}"
+              style="display:inline;">
+              {% csrf_token %}
+              <button type="submit" onclick="return confirm('대댓글을 삭제하시겠습니까?');">삭제</button>
+            </form>
+            {% else %}
+            <button>신고하기</button>
+            {% endif %}
           {% endif %}
         </div>
-        {% empty %}
-        <p>대댓글이 없습니다.</p>
-        {% endfor %}
+      {% empty %}
+      <p>대댓글이 없습니다.</p>
+      {% endfor %}
 
         <form method="post" action="{% url 'proposals:detail_reply_create' post.id comment.id %}">
           {% csrf_token %}
@@ -280,9 +280,9 @@
         </form>
       </div>
     </div>
-    {% empty %}
-    <p>아직 제안이 없습니다.</p>
-    {% endfor %}
+  {% empty %}
+  <p>아직 제안이 없습니다.</p>
+  {% endfor %}
 
     <h3>관련 아티클</h3>
     {% if post.community_post.related_article %}
@@ -295,8 +295,7 @@
           {{ post.community_post.related_article.title|truncatechars:30 }}
         </div>
         <div class="meta">
-          ❤️ {{ post.community_post.related_article.liked.count }} | 💬 {{
-          post.community_post.related_article.article_comments.count }}
+          ❤️ {{ post.community_post.related_article.liked.count }} | 💬 {{ post.community_post.related_article.article_comments.count }}
         </div>
       </div>
     </a>

--- a/theCommunityProject/proposals/templates/proposals_detail.html
+++ b/theCommunityProject/proposals/templates/proposals_detail.html
@@ -198,7 +198,7 @@
       <span style="background-color: gray">Best</span>
       {% endif %}
     </div>
-    <strong>{{ comment.user.username }}</strong>:
+    <!-- 제안 작성자의 아이디는 띄우지 않음 -->
     <p><strong>{{ comment.title }}</strong></p>
     <p><b>현황 및 문제점:</b> {{ comment.problem }}</p>
     <p><b>개선 방안:</b> {{ comment.solution }}</p>
@@ -241,7 +241,13 @@
     {% endif %}
       {% for reply in comment.proposal_replies.all %}
         <div id="reply_{{ reply.id }}">
-          <strong>{{ reply.user.username }}{% if reply.user == comment.user %} (글쓴이){% endif %}</strong>
+          <strong>
+            {% if reply.user == comment.user %}
+              글쓴이
+            {% else %}
+              {{ reply.anonymous_name }}
+            {% endif %}
+          </strong>
           <!-- 성별 출력 추가 -->
           <small>{% if reply.user.sex == 'M' %}(남성){% elif reply.user.sex == 'F' %}(여성){% else %}(기타){% endif %}</small>:
           {% if editing_reply_id == reply.id %}

--- a/theCommunityProject/proposals/templates/proposals_home.html
+++ b/theCommunityProject/proposals/templates/proposals_home.html
@@ -103,13 +103,13 @@
 
     <main>
         <div style="padding: 1rem 2rem;">
-            {% if request.GET.sort == 'popular' %}
+            {% if request.GET.sort == 'popular' or not request.GET.sort %}
             <strong>인기순</strong>
             {% else %}
             <a href="?sort=popular">인기순</a>
             {% endif %}
-            <!-- 최신순의 경우 기본 정렬도 포함 -->
-            {% if request.GET.sort == 'recent' or not request.GET.sort %}
+            <!-- 기본 정렬 인기순으로 변경 -->
+            {% if request.GET.sort == 'recent' %}
             <strong>최신순</strong>
             {% else %}
             <a href="?sort=recent">최신순</a>

--- a/theCommunityProject/proposals/views.py
+++ b/theCommunityProject/proposals/views.py
@@ -15,7 +15,7 @@ def home(request):
     proposals = ProposalPost.objects.all()
 
     # 정렬 추가
-    sort = request.GET.get('sort', 'recent')
+    sort = request.GET.get('sort', 'popular')
 
     if sort == 'popular':
         # 인기 점수: (좋아요 수 * 5) + (댓글 수 * 2)
@@ -86,7 +86,7 @@ def detail(request, post_id):
             editing_reply_id = None
 
     # 정렬/필터 파라미터 받기
-    sort = request.GET.get('sort', 'recent')  # 기본값: 최신순
+    sort = request.GET.get('sort', 'popular')  # 기본값: 인기순
     petition_filter = request.GET.get('filter', '')  # 기본값: 필터링 안 함
 
     # 기본 쿼리셋
@@ -101,6 +101,12 @@ def detail(request, post_id):
         comments = sorted(comments, key=lambda c: c.liked.count(), reverse=True)
     else:  # 최신순
         comments = comments.order_by('-created_at')
+
+    # Bets 기준(좋아요*5 + 답댓*2 >= 100)
+    for comment in comments:
+        likes = comment.liked.count()
+        replies = comment.proposal_replies.count()
+        comment.is_best = (likes * 5 + replies * 2) >= 100
 
     # 추천 아티클은 일단 임시로 최신순 5개로 정해둠
     recommended_articles = Article.objects.order_by('-created_at')[:5]


### PR DESCRIPTION
- 커뮤니티 부분 수정 x

1. 리스트(home), 댓글 기본 정렬 인기순으로 변경
2. 아이디 대신 익명n으로 출력하도록 뷰, 템플릿 수정(아티클 뷰 67, 76~100번 코드, detail 228, 269번 코드)
3. 아티클 상세 페이지에서 관련 커뮤니티 게시글 3개까지만 출력하도록 수정
4. 템플릿 오류(들여쓰기) 수정